### PR TITLE
Fix eval lint issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,7 +89,7 @@ ipython_config.py
 #   However, in case of collaboration, if having platform-specific dependencies or dependencies
 #   having no cross-platform support, pipenv may install dependencies that don't work, or not
 #   install all needed dependencies.
-#Pipfile.lock
+Pipfile.lock
 
 # PEP 582; used by e.g. github.com/David-OConnor/pyflow
 __pypackages__/

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,17 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+python-dateutil = "==2.8.1"
+python-decouple = "==3.3"
+requests = "==2.25.0"
+requests-oauthlib = "==1.3.0"
+twilio = "==6.50.0"
+google-cloud-secret-manager = "==2.1.0"
+
+[dev-packages]
+
+[requires]
+python_version = "3.9"

--- a/main.py
+++ b/main.py
@@ -90,9 +90,12 @@ def send_text(recipiant, payload):
         logger.error(message['error'])
     return message
 
-def unpack_data():
+def unpack_data(data):
     """Function to unpack data from its encoded form"""
     result = ""
+    result = base64.b64decode(data).decode('utf-8')
+    # TODO: what is this eval doing?  there should be a better way to do this in python. # pylint: disable=W0511
+    result = eval(result) #pylint disable:W0123
     return result
 
 def build_payload(alert):
@@ -109,9 +112,7 @@ def textalert(event, context):
     """Fucntion called by google cloud message """
     message = ''
     if 'data' in event:
-        data = base64.b64decode(event['data']).decode('utf-8')
-        # TODO: what is this eval doing?  there should be a better way to do this in python. # pylint: disable=W0511
-        data = eval(data) #pylint disable:W0123
+        data = unpack_data(event['data'])
     else:
         data = False
         message = r"No data passed in event consumed, "

--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@ and sends a text alert based on the payload passed to it in json)"""
 
 import base64
 import inspect
+import ast
 import logging
 import logging.handlers
 from decouple import config
@@ -95,7 +96,7 @@ def unpack_data(data):
     result = ""
     result = base64.b64decode(data).decode('utf-8')
     # TODO: what is this eval doing?  there should be a better way to do this in python. # pylint: disable=W0511
-    result = eval(result) #pylint disable:W0123
+    result = ast.literal_eval(result) #pylint disable:W0123
     return result
 
 def build_payload(alert):

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -1,5 +1,6 @@
+import base64
 from decouple import config
-from main import send_text, textalert
+from main import send_text, textalert, unpack_data
 
 twilio_account_sid = config('TWILIO_ACCOUNT_SID')
 twilio_auth_token = config('TWILIO_AUTH_TOKEN')
@@ -125,3 +126,11 @@ def test_textalert_with_nodata() -> None:
     event = {}
     context = {}
     textalert(event, context) == r'No data passed in event consumed, please check the producer is sending event[\'data\'\]'
+
+def test_unpack_data_with_encoded_data() -> None:
+    '''testing unpacking base64 encoded data - expected use case'''
+    message_data = {"alert":"Something happened!","recipiants":["+4412345678","+4423456789"]}
+    data = base64.b64encode(str(message_data).encode('utf8'))
+    unpacked_data = unpack_data(data)
+    assert unpacked_data['alert'] == message_data['alert']
+    assert unpacked_data['recipiants'] == message_data['recipiants']


### PR DESCRIPTION
**Fixing the linting issue using eval() to turn a str into a dict object type**
* * *

# What does this Pull Request do?
We have replaced the use of eval with ast.literal_eval which is a safer way to complete this task and passes the linting tests.

# What's new?
We are now importing an additional module ast, which will mean slightly longer runtimes.

Example:
* Moved the base64 decoding to its own function to make it testable.
* Added tests for base64 decoding.
* Removed the use of eval, replacing it with ast.literal_eval

# How should this be tested?

A description of what steps someone could take to:
* Ensure linting tests pass
* Ensure that when a request is fed in from google cloud framework, it is successfully decoded and a text is still sent.

# Checklist
- [x] Code contains tests for the feature/problem this PR is addressing
- [x] All tests pass


# Additional Notes:
Any additional information that you think would be helpful when reviewing this PR.

Example:
* Does this change require documentation to be updated?  - No
* Does this change add any new dependencies? yes ast module
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? yes

# Interested parties
@nslocomotives 
